### PR TITLE
Add a proper tool for Glowing Grass Blocks

### DIFF
--- a/src/main/java/com/finallion/artificialfoliage/block/ARFOGlowingGrassBlock.java
+++ b/src/main/java/com/finallion/artificialfoliage/block/ARFOGlowingGrassBlock.java
@@ -1,13 +1,14 @@
 package com.finallion.artificialfoliage.block;
 
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
+import net.fabricmc.fabric.api.tool.attribute.v1.FabricToolTags;
 import net.minecraft.block.Blocks;
 
 public class ARFOGlowingGrassBlock extends ARFOSpreadableBlock {
 
 
     public ARFOGlowingGrassBlock() {
-        super(FabricBlockSettings.copyOf(Blocks.GRASS_BLOCK).luminance(15));
+        super(FabricBlockSettings.copyOf(Blocks.GRASS_BLOCK).breakByTool(FabricToolTags.SHOVELS).luminance(15));
     }
 
 


### PR DESCRIPTION
Hello!
I believe this is unintended to not have any tool for Glowing Grass Blocks. Currently breaking them is a pain and this PR addresses that by making shovels the default tool for breaking them. 
If that is indeed intentional, feel free to close this PR, I don't mind.