### PR TITLE
Fixed breakage of vanilla mechanics and block dupe exploit

### DIFF
--- a/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
+++ b/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
@@ -30,7 +30,7 @@ public class MixinNetherrackBlock {
             }
         }
 
-        if (state.getBlock() != blockState.getBlock() && !(blockState.isOf(Blocks.AIR))) {
+        if (state.getBlock() != blockState.getBlock()) {
             if (blockState.isOf(ARFOBlocks.WARPED_NYLIUM_SLAB) || blockState.isOf(ARFOBlocks.GLOWING_WARPED_NYLIUM)) {
                 world.setBlockState(pos, Blocks.WARPED_NYLIUM.getDefaultState(), 2);
             } else if (blockState.isOf(ARFOBlocks.CRIMSON_NYLIUM_SLAB) || blockState.isOf(ARFOBlocks.GLOWING_CRIMSON_NYLIUM)) {

--- a/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
+++ b/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
@@ -35,8 +35,6 @@ public class MixinNetherrackBlock {
                 world.setBlockState(pos, Blocks.WARPED_NYLIUM.getDefaultState(), 2);
             } else if (blockState.isOf(ARFOBlocks.CRIMSON_NYLIUM_SLAB) || blockState.isOf(ARFOBlocks.GLOWING_CRIMSON_NYLIUM)) {
                 world.setBlockState(pos, Blocks.CRIMSON_NYLIUM.getDefaultState(), 2);
-            } else {
-                world.setBlockState(pos, blockState.getBlock().getDefaultState(), 2);
             }
         }
 

--- a/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
+++ b/src/main/java/com/finallion/artificialfoliage/mixin/MixinNetherrackBlock.java
@@ -30,7 +30,7 @@ public class MixinNetherrackBlock {
             }
         }
 
-        if (state.getBlock() != blockState.getBlock()) {
+        if (state.getBlock() != blockState.getBlock() && !(blockState.isOf(Blocks.AIR))) {
             if (blockState.isOf(ARFOBlocks.WARPED_NYLIUM_SLAB) || blockState.isOf(ARFOBlocks.GLOWING_WARPED_NYLIUM)) {
                 world.setBlockState(pos, Blocks.WARPED_NYLIUM.getDefaultState(), 2);
             } else if (blockState.isOf(ARFOBlocks.CRIMSON_NYLIUM_SLAB) || blockState.isOf(ARFOBlocks.GLOWING_CRIMSON_NYLIUM)) {


### PR DESCRIPTION
Hello!
Sorry for double PR. It will be more granular if I do them separately I though I suppose.
This PR addresses the issue where vanilla mechanics of Nylum spread would stop working since the mod would effectively replace the final block with whatever is at the end of block searching iterator (which can be any block, creating an exploit which could allow players to clone blocks). 
This removes the final else clause (which shouldn't be triggered by exiting break above anyways because we are looking for 4 specific blocks in the iterator). 
The final result of this PR is that if we don't find four specific blocks from AfRo we just pass the handling of function back to Minecraft instead of overwriting the block with one specific block at the end of block iterator.

Hope I were clear enough. If this implementation is not good enough, again, I don't mind closed PR, you can just treat it as a bug report then. :)
Hope you have a nice day.